### PR TITLE
Use html attributes as options

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -92,6 +92,14 @@ class media_jwplayer_plugin extends core_media_player {
         if (count($sources) > 0) {
             $playerid = 'media_jwplayer_media_' . html_writer::random_id();
 
+            // Create attribute options if we don't already have them.
+            if (empty($options['htmlattributes']) && !empty($options[core_media_manager::OPTION_ORIGINAL_TEXT])) {
+              $xml = new SimpleXMLElement($options[core_media_manager::OPTION_ORIGINAL_TEXT]);
+              foreach ($xml->attributes() as $attrib => $atval) {
+                $options['htmlattributes'][$attrib] = $atval;
+              }
+            }
+
             // Process data-jwplayer attributes.
             if (!empty($options['htmlattributes'])) {
                 foreach ($options['htmlattributes'] as $attrib => $atval) {


### PR DESCRIPTION

Fixes #6 .

The embed code is looking for `$options['htmlattributes']`, but `$options` only has keys `originaltext`, `trusted`, and `embedorblank`. 

This branch parses `$options['originaltext']` to identify the HTML attributes (if they weren’t already passed in) so the existing code can work as intended.
